### PR TITLE
Remove extraneous keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,10 @@ Commands for session related tasks.
 
 ## Usage
 
-    M-Space   new window
-    M-l       select next window
-    M-h       select prev window
-    M-Tab     select last window
-    M-L       move current window to right
-    M-H       move current window to left
-    M-Return  toggle pane fullscreen
-    M--       scroll up
-    M-+       scroll down
+    M-p       Open session finder (uses fzf)
+    M-`	      Go to next session
+    M-~	      Go to previous session
+    M-q       Go to the last session (toggle back and forth)
 
 ## Usage without install.bash
 
@@ -48,9 +43,9 @@ Switch to the previous session:
 Suggested config:
 
     set-option -g status-left ' #(./session-finder.bash status) '
+    bind-key -n 'M-p' new-window './session-finder.bash finder'
     bind-key -n 'M-`' run -b     './session-finder.bash next'
     bind-key -n 'M-~' run -b     './session-finder.bash prev'
     bind-key -n 'M-q' run -b     './session-finder.bash last'
-    bind-key -n 'M-p' new-window './session-finder.bash finder'
 
 Read [my blog post](http://siadat.github.io/tmux-session-management/) for more information.

--- a/session-finder.conf
+++ b/session-finder.conf
@@ -2,21 +2,7 @@
 # - Replace 'M' in keybindins with another modifier key, if necessary.
 # - If you have placed this file in somewhere other than ~/.tmux/session-finder, update the paths below.
 set-option -g status-left ' #(~/.tmux/session-finder/session-finder.bash status) '
+bind-key -n 'M-p' neww       '~/.tmux/session-finder/session-finder.bash finder'
 bind-key -n 'M-`' run -b     '~/.tmux/session-finder/session-finder.bash next'
 bind-key -n 'M-~' run -b     '~/.tmux/session-finder/session-finder.bash prev'
 bind-key -n 'M-q' run -b     '~/.tmux/session-finder/session-finder.bash last'
-bind-key -n 'M-p' neww       '~/.tmux/session-finder/session-finder.bash finder'
-bind-key -n 'M-l' select-window -t +1
-bind-key -n 'M-h' select-window -t -1
-bind-key -n 'M-j' select-pane -D
-bind-key -n 'M-k' select-pane -U
-bind-key -n 'M-H' swap-window -t -1
-bind-key -n 'M-L' swap-window -t +1
-bind-key -n 'M-v' split-window -v
-bind-key -n 'M-s' split-window -h
-bind-key -n 'M-Space' new-window -c "#{pane_current_path}"
-bind-key -n 'M-Enter' resize-pane -Z
-bind-key -n 'M-Tab' last-window
-bind-key -n 'M--' copy-mode \; send-keys C-u
-bind-key -n 'M-=' copy-mode \; send-keys C-d
-set-option -g escape-time 0


### PR DESCRIPTION
Since they were not related to session-finder itself.

Also re-order to list the finder keybinding first (since it is the main purpose of the package).

Fixes #1 